### PR TITLE
feat: dropping support for node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Get npm cache directory
         id: npm-cache-dir
@@ -40,13 +40,12 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node:
-          - 16
           - 18
           - 20
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Node ${{ matrix.node }}
         uses: actions/setup-node@v3
@@ -88,12 +87,12 @@ jobs:
 
   #   steps:
   #     - name: Checkout source
-  #       uses: actions/checkout@v3
+  #       uses: actions/checkout@v4
 
   #     - name: Install Node
   #       uses: actions/setup-node@v3
   #       with:
-  #         node-version: 16
+  #         node-version: 18
 
   #     - name: Get npm cache directory
   #       id: npm-cache-dir

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "typescript": "^5.1.6"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,24 @@
   "version": "2.0.0",
   "description": "A utility for parsing and validating data URLs.",
   "license": "ISC",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.cts",
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:readmeio/data-urls.git"
@@ -11,21 +29,6 @@
     "url": "https://github.com/readmeio/data-urls/issues"
   },
   "homepage": "https://github.com/readmeio/data-urls#readme",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
-    },
-    "./package.json": "./package.json"
-  },
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
-  "sideEffects": false,
-  "engines": {
-    "node": ">=14"
-  },
   "scripts": {
     "build": "tsup",
     "lint": "eslint . --ext .js,.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "declaration": true,
     "esModuleInterop": true,
     "lib": ["DOM", "ES2020"],
-    "moduleResolution": "node",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "noImplicitAny": true,
     "outDir": "dist/",
     "target": "ES2020"


### PR DESCRIPTION
## 🧰 Changes

* [x] Drop support for Node 14 and Node 16.
* [x] Fixes the way we export CJS and ESM exports so it can work in `NodeNext`. See https://github.com/readmeio/oas-normalize/pull/294 for context.